### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,8 +17,8 @@ on	KEYWORD2
 off	KEYWORD2
 blink	KEYWORD2
 blinking	KEYWORD2
-setCycleLen KEYWORD2
-setDutyCycle KEYWORD2
+setCycleLen	KEYWORD2
+setDutyCycle	KEYWORD2
 update	KEYWORD2
 state	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords